### PR TITLE
アツマールAPIとの連携機能を追加

### DIFF
--- a/src/scene_title.cpp
+++ b/src/scene_title.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <emscripten.h>
 #include "scene_title.h"
 #include "audio.h"
 #include "audio_secache.h"
@@ -47,6 +48,10 @@ Scene_Title::Scene_Title() {
 
 void Scene_Title::Start() {
 	Main_Data::game_system->ResetSystemGraphic();
+
+	EM_ASM({
+		callAtsumaruApi('setcommentgpos');
+	});
 
 	// Skip background image and music if not used
 	if (CheckEnableTitleGraphicAndMusic()) {

--- a/src/window_message.cpp
+++ b/src/window_message.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <sstream>
 #include <iterator>
+#include <emscripten.h>
 
 #include "compiler.h"
 #include "window_message.h"
@@ -179,6 +180,10 @@ void Window_Message::StartMessageProcessing(PendingMessage pm) {
 	item_max = min(4, pending_message.GetNumChoices());
 
 	text_index = text.data();
+
+	EM_ASM({
+		callAtsumaruApi('setcommentgpos', $0, UTF8ToString($1));
+	}, Game_Map::GetMapId(), text_index);
 
 	DebugLog("{}: MSG TEXT \n{}", text);
 


### PR DESCRIPTION
- 注釈コマンドにDynRPGスタイルの命令コマンドが来た場合、アツマール側で定義する `callAtsumaruApi` 関数に転送します
- 文章の表示コマンド及びタイトル画面に戻ってきた場合、アツマール側で定義する `callAtsumaruApi` 関数の `SetCommentGpos` にGPOS V3を再現するのに必要な情報を転送します